### PR TITLE
Migrating to Flexible SQL Servers (MySQL, PostgreSQL)

### DIFF
--- a/octopus-samples-instances/azure-base-infrastructure-terraform/azure-mysql.tf
+++ b/octopus-samples-instances/azure-base-infrastructure-terraform/azure-mysql.tf
@@ -1,37 +1,37 @@
-resource "azurerm_mysql_server" "permanent" {
-    name                             = var.azure_mysql_name
-    resource_group_name              = azurerm_resource_group.permanent.name
-    location                         = azurerm_resource_group.permanent.location
-    
-    administrator_login              = var.azure_mysql_administrator_name
-    administrator_login_password     = var.azure_mysql_administrator_password
+resource "azurerm_mysql_flexible_server" "permanent" {
+  name                = var.azure_mysql_name
+  resource_group_name = azurerm_resource_group.permanent.name
+  location            = azurerm_resource_group.permanent.location
 
-    sku_name                         = "B_Gen5_2"
-    version                          = "8.0"
-    storage_mb                       = 5120
-    backup_retention_days            = 7
-    geo_redundant_backup_enabled     = false
-    auto_grow_enabled                = false
-    public_network_access_enabled    = true
-    ssl_enforcement_enabled          = true
-    ssl_minimal_tls_version_enforced = "TLS1_2"
+  administrator_login    = var.azure_mysql_administrator_name
+  administrator_password = var.azure_mysql_administrator_password
 
-    tags = {
-        LifetimeInDays = 365
-    }
+  sku_name                     = "B_Standard_B1ms"
+  version                      = "8.0"
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+
+  storage {
+    auto_grow_enabled = false
+    size_gb           = 20
+  }
+
+  tags = {
+    LifetimeInDays = 365
+  }
 }
 
-resource "azurerm_mysql_firewall_rule" "all_azure_resources" {
+resource "azurerm_mysql_flexible_server_firewall_rule" "all_azure_resources" {
   name                = "all-azure-resources"
   resource_group_name = azurerm_resource_group.permanent.name
-  server_name         = azurerm_mysql_server.permanent.name
+  server_name         = azurerm_mysql_flexible_server.permanent.name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
 }
 
-resource "azurerm_mysql_configuration" "log_bin_trust_function_creators" {
+resource "azurerm_mysql_flexible_server_configuration" "log_bin_trust_function_creators" {
   name                = "log_bin_trust_function_creators"
   resource_group_name = azurerm_resource_group.permanent.name
-  server_name         = azurerm_mysql_server.permanent.name
+  server_name         = azurerm_mysql_flexible_server.permanent.name
   value               = "ON"
 }

--- a/octopus-samples-instances/azure-base-infrastructure-terraform/azure-mysql.tf
+++ b/octopus-samples-instances/azure-base-infrastructure-terraform/azure-mysql.tf
@@ -8,7 +8,7 @@ resource "azurerm_mysql_flexible_server" "permanent" {
 
   sku_name                     = "B_Standard_B1ms"
   version                      = "8.0"
-  backup_retention_days        = 7
+  backup_retention_days        = 1
   geo_redundant_backup_enabled = false
 
   storage {

--- a/octopus-samples-instances/azure-base-infrastructure-terraform/azure-postgresql.tf
+++ b/octopus-samples-instances/azure-base-infrastructure-terraform/azure-postgresql.tf
@@ -1,30 +1,27 @@
-resource "azurerm_postgresql_server" "permanent" {
-    name                             = var.azure_postresql_name
-    resource_group_name              = azurerm_resource_group.permanent.name
-    location                         = azurerm_resource_group.permanent.location
-    
-    administrator_login              = var.azure_postgresql_administrator_name
-    administrator_login_password     = var.azure_postgresql_administrator_password
+resource "azurerm_postgresql_flexible_server" "permanent" {
+  name                = var.azure_postresql_name
+  resource_group_name = azurerm_resource_group.permanent.name
+  location            = azurerm_resource_group.permanent.location
 
-    sku_name                         = "B_Gen5_1"
-    version                          = "11"
-    storage_mb                       = 5120
-    backup_retention_days            = 7
-    geo_redundant_backup_enabled     = false
-    auto_grow_enabled                = false
-    public_network_access_enabled    = true
-    ssl_enforcement_enabled          = true
-    ssl_minimal_tls_version_enforced = "TLS1_2"
+  administrator_login    = var.azure_postgresql_administrator_name
+  administrator_password = var.azure_postgresql_administrator_password
 
-    tags = {
-        LifetimeInDays = 365
-    }    
+  sku_name                     = "B_Standard_B1ms"
+  version                      = "11"
+  storage_mb                   = 5120
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+
+  tags = {
+    LifetimeInDays = 365
+  }
+
 }
 
-resource "azurerm_postgresql_firewall_rule" "all_azure_resources" {
-  name                = "all-azure-resources"
-  resource_group_name = azurerm_resource_group.permanent.name
-  server_name         = azurerm_postgresql_server.permanent.name
-  start_ip_address    = "0.0.0.0"
-  end_ip_address      = "0.0.0.0"
+resource "azurerm_postgresql_flexible_server_firewall_rule" "all_azure_resources" {
+  name      = "all-azure-resources"
+  server_id = azurerm_postgresql_flexible_server.permanent.id
+
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
 }


### PR DESCRIPTION
Migrating from standard single server resources to flexible server resources. This is currently only required for MySQL ([single server is retiring)](https://azure.microsoft.com/en-us/updates/action-required-migrate-to-azure-database-for-mysql-flexible-server-by-16-september-2024).

Changes are largely in the resource naming, minus a few alterations to account for the new resources:
* The configuration for sku_name has changed on both servers to `B_Standard_B1ms` to minimize cost
* Configuration for ssl/tls and public access has been removed (no longer present, implied by new default resource behavior)
* A little cheese moving to manage new resource structures (e.g. `storage` block for postgres)
