### PR TITLE
Updating script to new CLI

### DIFF
--- a/octopus-samples-instances/api-scripts/call-enforce-space-standards-runbook.ps1
+++ b/octopus-samples-instances/api-scripts/call-enforce-space-standards-runbook.ps1
@@ -86,9 +86,13 @@ if ([string]::IsNullOrWhiteSpace($OptionalSpaceId) -eq $false -and $OptionalSpac
     $spacesList = @($spacesList | Where-Object {$_.Id -eq $OptionalSpaceId})
 }
 
+# Set environment variables for octopus cli execution
+$env:OCTOPUS_URL = $AdminInstanceUrl
+$env:OCTOPUS_API_KEY = $AdminInstanceApiKey
+
 foreach ($space in $spacesList)
 {
     Write-Host "Queueing a runbook run for $($space.Name) using the space id $($space.Id).  The runbook will run on $AdminInstanceUrl for the environment $AdminEnvironmentName in the space $AdminSpaceName"
-    Write-Host "Running command: octo run-runbook --project ""Standards"" --runbook ""Enforce Space Standards"" --environment ""$AdminEnvironmentName"" --variable=""Project.Standards.SpaceId:$($space.Id)"" --server=""$AdminInstanceUrl"" --apiKey=""$AdminInstanceApiKey"" --space=""$AdminSpaceName"" to queue the runbook"
-    octo run-runbook --project "Standards" --runbook "Enforce Space Standards" --environment "$AdminEnvironmentName" --variable="Project.Standards.SpaceId:$($space.Id)" --server="$AdminInstanceUrl" --apiKey="$AdminInstanceApiKey" --space="$AdminSpaceName"
+    Write-Host "Running command: octopus runbook run --project ""Standards"" --name ""Enforce Space Standards"" --environment ""$AdminEnvironmentName"" --variable=""Project.Standards.SpaceId:$($space.Id)"" --space=""$AdminSpaceName"" to queue the runbook"
+    octopus runbook run --project "Standards" --name "Enforce Space Standards" --environment "$AdminEnvironmentName" --variable="Project.Standards.SpaceId:$($space.Id)" --space="$AdminSpaceName"
 }


### PR DESCRIPTION
Script relied on legacy `octo` to execute a runbook.  This updates the script to use `octopus` cli.